### PR TITLE
Add Docker instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:16.04
+
+RUN apt update
+RUN apt install -y openjdk-8-jdk
+ADD . /src
+WORKDIR /src
+RUN ./gradlew expand

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ sudo docker build -t brown-uk/dict_uk .
 sudo docker run -d --name dict_uk brown-uk/dict_uk /bin/bash
 sudo docker cp dict_uk:/src/out/ ./out
 sudo chown -R $USER: ./out
+sudo docker stop dict_uk
 ```
 
 ### License ###

--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@
 * out/words_spell.txt - words valid for spelling
 * out/lemmas.txt - list of unique lemmas
 
+### Building under docker ###
+
+```
+sudo docker build -t brown-uk/dict_uk .
+sudo docker run -d --name dict_uk brown-uk/dict_uk /bin/bash
+sudo docker cp dict_uk:/src/out/ ./out
+sudo chown -R $USER: ./out
+```
+
+### License ###
 
 Дані словника доступні для використання згідно з умовами ліцензії "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License" (http://creativecommons.org/licenses/by-nc-sa/4.0/)
 Програмні засоби вільно розповсюджується за умов ліцензії GPL версії 3.


### PR DESCRIPTION
Since I had troubles building this on Ubuntu 17.10 (see https://github.com/brown-uk/dict_uk/issues/151 ), I've made a Dockerfile and instructions which will help launching the builder.